### PR TITLE
Add missing include for recent GCC

### DIFF
--- a/ministat.c
+++ b/ministat.c
@@ -14,6 +14,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <err.h>
 #include <sys/ioctl.h>
 #include <sys/queue.h>
 


### PR DESCRIPTION
This prevents the following error when building on Arch

```console
==> Starting build()...
gcc -lm ministat.c -o ministat
ministat.c: In function ‘ReadSet’:
ministat.c:484:17: error: implicit declaration of function ‘err’; did you mean ‘erf’? [-Wimplicit-function-declaration]
  484 |                 err(1, "Cannot open %s", n);
      |                 ^~~
      |                 erf
make: *** [Makefile:7: ministat] Error 1
==> ERROR: A failure occurred in build().
    Aborting...
 -> error making: ministat-git-exit status 4
```